### PR TITLE
Remove get_implementation functionality

### DIFF
--- a/src/analyses/apron/apronAnalysis.apron.ml
+++ b/src/analyses/apron/apronAnalysis.apron.ml
@@ -1,12 +1,14 @@
 (** {{!RelationAnalysis} Relational integer value analysis} using {!Apron} domains ([apron]). *)
 
 open Analyses
+open RelationalImplementation
+open ApronImplementation
 
 include RelationAnalysis
 
 let spec_module: (module MCPSpec) Lazy.t =
   lazy (
-    let module RelImpl = (val ApronDomain.get_implementation "apron") in
+    let module RelImpl : Implementation = ApronImplementation in
     let module Man = (val ApronDomain.get_manager (module RelImpl)) in
     let module AD = ApronDomain.D2 (Man) in
     let diff_box = GobConfig.get_bool "ana.apron.invariant.diff-box" in

--- a/src/analyses/apron/elinaAnalysis.elina.ml
+++ b/src/analyses/apron/elinaAnalysis.elina.ml
@@ -1,12 +1,14 @@
 (** {{!RelationAnalysis} Relational integer value analysis} using {!Elina} domains ([elina]). *)
 
 open Analyses
+open RelationalImplementation
+open ElinaImplementation
 
 include RelationAnalysis
 
 let spec_module: (module MCPSpec) Lazy.t =
   lazy (
-    let module RelImpl = (val ApronDomain.get_implementation "elina") in
+    let module RelImpl : Implementation = ElinaImplementation in
     let module Man = (val ApronDomain.get_manager (module RelImpl)) in
     let module AD = ApronDomain.D2 (Man) in
     let diff_box = GobConfig.get_bool "ana.apron.invariant.diff-box" in

--- a/src/cdomains/apron/apronDomain.apron.ml
+++ b/src/cdomains/apron/apronDomain.apron.ml
@@ -8,45 +8,10 @@ open GobApron
 open RelationDomain
 open SharedFunctions
 
-
 (* Relational anaylsis implementation selection *)
+open RelationalImplementation
 open ApronImplementation
 open ElinaImplementation
-
-module type Implementation =
-sig
-  (* Oct *)
-  type t
-  val to_oct : 'a Apron.Abstract1.t -> t Apron.Abstract1.t
-  val of_oct : t Apron.Abstract1.t -> 'a Apron.Abstract1.t
-  val widening_thresholds : t Apron.Manager.t -> t Apron.Abstract0.t -> t Apron.Abstract0.t -> Apron.Scalar.t array -> t Apron.Abstract0.t
-  val manager_is_oct : 'a Apron.Manager.t -> bool
-  val manager_to_oct : 'a Apron.Manager.t -> t Apron.Manager.t
-  val substitute_texpr_with : 'a Apron.Manager.t -> 'a Apron.Abstract1.t -> Apron.Var.t -> Apron.Texpr1.t -> 'a Apron.Abstract1.t option -> unit
-  val narrowing : t Apron.Manager.t -> t Apron.Abstract0.t -> t Apron.Abstract0.t -> t Apron.Abstract0.t
-  val manager_alloc : unit -> t Apron.Manager.t
-  (* Poly *)
-  type pt
-  val manager_alloc_loose : unit -> pt Apron.Manager.t
-  (* Other *)
-  val hash : 'a Apron.Manager.t -> 'a Apron.Abstract1.t -> int
-  val impl : unit -> string
-  val bound_texpr : 'a Manager.t -> string -> 'a Abstract1.t -> Texpr1.t -> Interval.t
-end
-
-let implementation impl =
-  lazy (
-    if impl = "apron" then
-      (module ApronImplementation : Implementation)
-    else if impl = "elina" then
-      (module ElinaImplementation : Implementation)
-    else
-      failwith @@ "Relational analysis implementation " ^ impl ^ " is not supported."
-  )
-
-let get_implementation impl: (module Implementation) =
-  Lazy.force (implementation impl)
-(* Relational anaylsis implementation selection End *)
 
 module M = Messages
 

--- a/src/cdomains/apron/elinaImplementation.elina.ml
+++ b/src/cdomains/apron/elinaImplementation.elina.ml
@@ -102,7 +102,6 @@ module ElinaImplementation = struct
       one
     
   let bound_texpr_pow i1 i2 s1 s2 =
-    (* TO DO *)
     mts (bound_texpr_pow_rec (stm i1) (stm i2)) (bound_texpr_pow_rec (stm s1) (stm s2))
 
   (* Unop/Sqrt case *)

--- a/src/cdomains/apron/elinaImplementation.no-elina.ml
+++ b/src/cdomains/apron/elinaImplementation.no-elina.ml
@@ -1,3 +1,0 @@
-(* If elina is not present, we use the apron implementation *)
-open ApronImplementation
-module ElinaImplementation = ApronImplementation

--- a/src/cdomains/apron/relationalImplementation.apron.ml
+++ b/src/cdomains/apron/relationalImplementation.apron.ml
@@ -1,0 +1,22 @@
+open Apron
+
+module type Implementation =
+sig
+  (* Oct *)
+  type t
+  val to_oct : 'a Apron.Abstract1.t -> t Apron.Abstract1.t
+  val of_oct : t Apron.Abstract1.t -> 'a Apron.Abstract1.t
+  val widening_thresholds : t Apron.Manager.t -> t Apron.Abstract0.t -> t Apron.Abstract0.t -> Apron.Scalar.t array -> t Apron.Abstract0.t
+  val manager_is_oct : 'a Apron.Manager.t -> bool
+  val manager_to_oct : 'a Apron.Manager.t -> t Apron.Manager.t
+  val narrowing : t Apron.Manager.t -> t Apron.Abstract0.t -> t Apron.Abstract0.t -> t Apron.Abstract0.t
+  val manager_alloc : unit -> t Apron.Manager.t
+  (* Poly *)
+  type pt
+  val manager_alloc_loose : unit -> pt Apron.Manager.t
+  (* Other *)
+  val impl : unit -> string
+  val substitute_texpr_with : 'a Apron.Manager.t -> 'a Apron.Abstract1.t -> Apron.Var.t -> Apron.Texpr1.t -> 'a Apron.Abstract1.t option -> unit
+  val hash : 'a Apron.Manager.t -> 'a Apron.Abstract1.t -> int
+  val bound_texpr : 'a Manager.t -> string -> 'a Abstract1.t -> Texpr1.t -> Interval.t
+end

--- a/src/dune
+++ b/src/dune
@@ -15,6 +15,10 @@
       (apron -> gobApron.apron.ml)
       (-> gobApron.no-apron.ml)
     )
+    (select relationalImplementation.ml from
+      (apron -> relationalImplementation.apron.ml)
+      (-> relationalImplementation.no-apron.ml)
+    )
     (select apronImplementation.ml from
       (apron -> apronImplementation.apron.ml)
       (-> apronImplementation.no-apron.ml)

--- a/src/util/apron/apronPrecCompareUtil.apron.ml
+++ b/src/util/apron/apronPrecCompareUtil.apron.ml
@@ -2,6 +2,8 @@
 
 open PrecCompareUtil
 open ApronDomain
+open RelationalImplementation
+open ApronImplementation
 
 (* Currently serialization of Apron results only works for octagons. *)
 module OctagonD = ApronDomain.OctagonD
@@ -14,7 +16,7 @@ module Util =
     type result = Dom.t RH.t result_gen
 
     let init () =
-      let module ApronImpl = (val ApronDomain.get_implementation "apron") in
+      let module ApronImpl : Implementation = ApronImplementation in
       let module OctagonManagerInstance = OctagonManager (ApronImpl) in 
       Apron.Manager.set_deserialize OctagonManagerInstance.mgr
 


### PR DESCRIPTION
in favor of the implementation being hardcoded into apron/elina analyses this makes it so elina implementation can be empty without elina instead of needing to be set to be equal to apron analysis